### PR TITLE
wilderness-clan-callouts

### DIFF
--- a/plugins/Wilderness-clan-callouts
+++ b/plugins/Wilderness-clan-callouts
@@ -1,0 +1,2 @@
+repository=https://github.com/Gerbzz/WildernessClanCallouts.git
+commit=7c45f456c0e4c2ec030f8e08ef7169f032cc65e8


### PR DESCRIPTION
The "WildernessClanCallouts" plugin is a RuneScape plugin that allows players to quickly and easily call out the names of enemies in the Wilderness with a customizable prefix and hotkey. The plugin also has the option to shorten the enemy's name to 3 characters for faster typing. This plugin is useful for players who frequently participate in player vs player combat in the Wilderness and want to quickly and easily communicate the names of their enemies to their team.